### PR TITLE
Use the standard directory for file downloads. Fixes #291

### DIFF
--- a/SWADroid/src/main/java/es/ugr/swad/swadroid/Constants.java
+++ b/SWADroid/src/main/java/es/ugr/swad/swadroid/Constants.java
@@ -324,7 +324,7 @@ public class Constants {
      */
     public static final String DIRECTORY_SWADROID = "SWADroid";
     public static final String DOWNLOADS_PATH =
-            Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + DIRECTORY_SWADROID;
+            Environment.DIRECTORY_DOWNLOADS + File.separator + DIRECTORY_SWADROID;
 
     /**
      * Username template for messages

--- a/SWADroid/src/main/java/es/ugr/swad/swadroid/modules/downloads/DownloadFactory.java
+++ b/SWADroid/src/main/java/es/ugr/swad/swadroid/modules/downloads/DownloadFactory.java
@@ -21,20 +21,14 @@ package es.ugr.swad.swadroid.modules.downloads;
 import android.annotation.TargetApi;
 import android.app.DownloadManager;
 import android.content.Context;
-import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.util.Log;
-import android.widget.Toast;
 
-import java.io.File;
-import java.util.List;
 import java.util.Locale;
 
 import es.ugr.swad.swadroid.Constants;
-import es.ugr.swad.swadroid.utils.Utils;
 
 /**
  * Class for manage file downloads
@@ -60,56 +54,24 @@ public class DownloadFactory {
 			String description) {
 		
 		Uri uri = Uri.parse(url);	 
-	    DownloadManager managerHoneycomb;
-		DownloadManager.Request requestHoneycomb;
-	    es.ugr.swad.swadroid.modules.downloads.DownloadManager managerGingerbread;
-	    es.ugr.swad.swadroid.modules.downloads.DownloadManager.Request requestGingerbread;
-	    
-	    //Create destination directory if not exists
-	    File downloadDirectory = new File(Constants.DOWNLOADS_PATH);
-	    if (!downloadDirectory.exists()){
-	    	if(downloadDirectory.mkdir()) {
-	            Log.i(TAG, "Created directory " + Constants.DOWNLOADS_PATH);
-            } else {
-                Log.e(TAG, "Error creating directory " + Constants.DOWNLOADS_PATH);
-                Toast.makeText(context, "Error creating directory " + Constants.DOWNLOADS_PATH, Toast.LENGTH_LONG).show();
-                return false;
-            }
-        }
+	    DownloadManager manager;
+		DownloadManager.Request request;
 
-		managerHoneycomb = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-		requestHoneycomb = new DownloadManager.Request(uri);
+		manager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+		request = new DownloadManager.Request(uri);
 
-		requestHoneycomb.setDescription(title);
-		requestHoneycomb.setTitle(description);
-		requestHoneycomb.setDestinationInExternalPublicDir(Constants.DIRECTORY_SWADROID, fileName);
+		request.setDescription(title);
+		request.setTitle(description);
+		request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Constants.DIRECTORY_SWADROID + "/" + fileName);
 
-		//DownloadManager HONEYCOMB
-		Log.i(TAG, "Downloading file " + fileName + " with DownloadManager >= HONEYCOMB");
+		Log.i(TAG, "Downloading file " + fileName);
 
-		requestHoneycomb.allowScanningByMediaScanner();
-		requestHoneycomb.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+		request.allowScanningByMediaScanner();
+		request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
 
-		managerHoneycomb.enqueue(requestHoneycomb);
+		manager.enqueue(request);
 	
 	    return true;
-	}
-
-	/**
-	 * @param context used to check the device version and DownloadManager information
-	 * @return true if the download manager is available
-	 */
-	public static boolean isDownloadManagerAvailable(Context context) {
-	    try {
-	        Intent intent = new Intent(Intent.ACTION_MAIN);
-	        intent.addCategory(Intent.CATEGORY_LAUNCHER);
-	        intent.setClassName("com.android.providers.downloads.ui", "com.android.providers.downloads.ui.DownloadList");
-	        List<ResolveInfo> list = context.getPackageManager().queryIntentActivities(intent,
-	                PackageManager.MATCH_DEFAULT_ONLY);
-	        return list.size() > 0;
-	    } catch (Exception e) {
-	        return false;
-	    }
 	}
 
 	/**

--- a/SWADroid/src/main/java/es/ugr/swad/swadroid/modules/downloads/DownloadFactory.java
+++ b/SWADroid/src/main/java/es/ugr/swad/swadroid/modules/downloads/DownloadFactory.java
@@ -26,6 +26,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.util.Log;
 
+import java.io.File;
 import java.util.Locale;
 
 import es.ugr.swad.swadroid.Constants;
@@ -62,7 +63,7 @@ public class DownloadFactory {
 
 		request.setDescription(title);
 		request.setTitle(description);
-		request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Constants.DIRECTORY_SWADROID + "/" + fileName);
+		request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, Constants.DIRECTORY_SWADROID + File.separator + fileName);
 
 		Log.i(TAG, "Downloading file " + fileName);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Use the standard directory for file downloads.
* For applications targeting `Build.VERSION_CODES.Q` or above, `WRITE_EXTERNAL_STORAGE` permission is not needed and the dirType must be one of the known public directories like `Environment#DIRECTORY_DOWNLOADS, Environment#DIRECTORY_PICTURES, Environment#DIRECTORY_MOVIES`, etc.

## How was this patch tested?

Manually. Tested on Android 11 (API 30) and Android 7 (API 24).
